### PR TITLE
Change module format to es6

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   presets: [
     ["@babel/preset-env", {}],
   ],

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { importDeclaration, stringLiteral, isStringLiteral, callExpression } from '@babel/types';
-import { NODE14_BUILTIN_MODULES } from './constants';
+import { NODE14_BUILTIN_MODULES } from './constants.js';
 
 function err(msg) {
   throw new Error('Napkin Modules: ' + msg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "babel-plugin-napkin-modules",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "babel-plugin-napkin-modules",
-            "version": "0.0.4",
+            "version": "0.1.0",
             "license": "None",
             "dependencies": {
                 "@babel/types": "^7.16.0"
@@ -1799,10 +1799,16 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -1868,7 +1874,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
         "node_modules/convert-source-map": {
@@ -2042,7 +2048,7 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
         "node_modules/fsevents": {
@@ -2098,9 +2104,9 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -2127,6 +2133,18 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/globals": {
@@ -2192,7 +2210,7 @@
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
@@ -2232,7 +2250,7 @@
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2498,50 +2516,50 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+            "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": "*"
+                "node": ">=10"
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "node_modules/mocha": {
-            "version": "9.1.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-            "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+            "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
             "dev": true,
             "dependencies": {
                 "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.2",
-                "debug": "4.3.2",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.7",
+                "glob": "7.2.0",
                 "growl": "1.10.5",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
-                "minimatch": "3.0.4",
+                "minimatch": "4.2.1",
                 "ms": "2.1.3",
-                "nanoid": "3.1.25",
+                "nanoid": "3.3.1",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
-                "workerpool": "6.1.5",
+                "workerpool": "6.2.0",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
@@ -2557,29 +2575,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/mochajs"
             }
-        },
-        "node_modules/mocha/node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/mocha/node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
         },
         "node_modules/mocha/node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -2700,9 +2695,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -2756,7 +2751,7 @@
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
@@ -2810,7 +2805,7 @@
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2829,9 +2824,9 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
             "engines": {
                 "node": ">=8.6"
@@ -3180,9 +3175,9 @@
             }
         },
         "node_modules/workerpool": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-            "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+            "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
             "dev": true
         },
         "node_modules/wrap-ansi": {
@@ -3238,7 +3233,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
         },
         "node_modules/y18n": {
@@ -4556,9 +4551,9 @@
             }
         },
         "chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.2",
@@ -4617,7 +4612,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
         "convert-source-map": {
@@ -4745,7 +4740,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
         "fsevents": {
@@ -4785,9 +4780,9 @@
             }
         },
         "glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -4796,6 +4791,17 @@
                 "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+            },
+            "dependencies": {
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
             }
         },
         "glob-parent": {
@@ -4849,7 +4855,7 @@
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "dev": true,
             "requires": {
                 "once": "^1.3.0",
@@ -4883,7 +4889,7 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true
         },
         "is-fullwidth-code-point": {
@@ -5072,69 +5078,52 @@
             }
         },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+            "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
             "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "mocha": {
-            "version": "9.1.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-            "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+            "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
                 "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "chokidar": "3.5.2",
-                "debug": "4.3.2",
+                "chokidar": "3.5.3",
+                "debug": "4.3.3",
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.7",
+                "glob": "7.2.0",
                 "growl": "1.10.5",
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
-                "minimatch": "3.0.4",
+                "minimatch": "4.2.1",
                 "ms": "2.1.3",
-                "nanoid": "3.1.25",
+                "nanoid": "3.3.1",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
-                "workerpool": "6.1.5",
+                "workerpool": "6.2.0",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
             },
             "dependencies": {
-                "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    },
-                    "dependencies": {
-                        "ms": {
-                            "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                            "dev": true
-                        }
-                    }
-                },
                 "escape-string-regexp": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -5214,9 +5203,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
             "dev": true
         },
         "node-releases": {
@@ -5252,7 +5241,7 @@
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
             "requires": {
                 "wrappy": "1"
@@ -5291,7 +5280,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true
         },
         "path-parse": {
@@ -5307,9 +5296,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true
         },
         "pify": {
@@ -5575,9 +5564,9 @@
             }
         },
         "workerpool": {
-            "version": "6.1.5",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-            "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+            "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
             "dev": true
         },
         "wrap-ansi": {
@@ -5620,7 +5609,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
         },
         "y18n": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "babel-plugin-napkin-modules",
-    "version": "0.0.5",
+    "version": "0.1.0",
+    "type": "module",
     "description": "Transforms import and require statements into ones with packages versions if specified (import x from 'y' -> import x from 'y-1.0.1' and require('y') -> require('y-1.0.1')",
     "keywords": [
         "babel",

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { transform as babelTransform } from '@babel/core';
+import { transformAsync as babelTransform } from '@babel/core';
 
 const es6Option = { modules: false }
 
@@ -10,78 +10,95 @@ const defaultPluginOptions = {
   }
 };
 
-function transform(code, transformOptions = {}, pluginOptions = defaultPluginOptions) {
-  return babelTransform(code, {
+async function transform(code, transformOptions = {}, pluginOptions = defaultPluginOptions) {
+  const transformResult = await babelTransform(code, {
     presets: [['@babel/preset-env', transformOptions]],
     plugins: [['./index', pluginOptions]]
-  }).code;
+  })
+
+  return transformResult.code
 }
 
-describe('es6', function () {
-  describe('import transformations', function () {
-    it('should handle imports', function () {
+describe('es6', async function () {
+  describe('import transformations', async function () {
+    it('should handle imports', async function () {
       const code = "import moment from 'moment'; import ethers from 'ethers'; console.log(moment.now());";
-      assert.equal(transform(code, es6Option), "import moment from \"moment\";\nimport ethers from \"ethers-1.0.1\";\nconsole.log(moment.now());");
+      const actual = await transform(code, es6Option)
+      assert.equal(actual, "import moment from \"moment\";\nimport ethers from \"ethers-1.0.1\";\nconsole.log(moment.now());");
     });
-
-    it('should error when a module is not included in the object', function () {
+    
+    it('should error when a module is not included in the object', async function () {
       const code = "import moment from 'moment'; import ethers from 'ethers'; import notamodule from 'notamodule'; console.log(moment.now());";
-      assert.throws(() => { transform(code, es6Option) }, Error, 'Napkin Modules: notamodule not found');
-    });
-  });
-
-  describe('call expression transformations', function () {
-    it('should handle requires without affecting other call expressions', function () {
-      const code = "const moment = require('moment'); const ethers = require('ethers'); console.log(moment.now());";
-      assert.equal(transform(code, es6Option), "var moment = require(\"moment\");\n\nvar ethers = require(\"ethers-1.0.1\");\n\nconsole.log(moment.now());");
-    });
-
-    it('should error when a module is not included in the object', function () {
-      const code = "const moment = require('moment'); const ethers = require('ethers'); const notamodule = require('notamodule'); console.log(moment.now());";
-      assert.throws(() => { transform(code, es6Option) }, Error, 'Napkin Modules: notamodule not found');
+      await assert.rejects(transform(code, es6Option));
     });
   });
 });
 
-describe('commonjs', function () {
-  describe('import transformations', function () {
-    it('should handle imports', function () {
+describe('es6', async function () {
+  describe('import transformations', async function () {
+    it('should handle imports', async function () {
       const code = "import moment from 'moment'; import ethers from 'ethers'; console.log(moment.now());";
-      assert.equal(transform(code), "\"use strict\";\n\nvar _moment = _interopRequireDefault(require(\"moment\"));\n\nvar _ethers = _interopRequireDefault(require(\"ethers-1.0.1\"));\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { \"default\": obj }; }\n\nconsole.log(_moment[\"default\"].now());");
+      assert.equal(await transform(code, es6Option), "import moment from \"moment\";\nimport ethers from \"ethers-1.0.1\";\nconsole.log(moment.now());");
     });
 
-    it('should error when a module is not included in the object', function () {
+    it('should error when a module is not included in the object', async function () {
       const code = "import moment from 'moment'; import ethers from 'ethers'; import notamodule from 'notamodule'; console.log(moment.now());";
-      assert.throws(() => { transform(code) }, Error, 'Napkin Modules: notamodule not found');
+      await assert.rejects(transform(code, es6Option), Error, 'Napkin Modules: notamodule not found');
+    });
+  });
+
+  describe('call expression transformations', async function () {
+    it('should handle requires without affecting other call expressions', async function () {
+      const code = "const moment = require('moment'); const ethers = require('ethers'); console.log(moment.now());";
+      assert.equal(await transform(code, es6Option), "var moment = require(\"moment\");\n\nvar ethers = require(\"ethers-1.0.1\");\n\nconsole.log(moment.now());");
+    });
+
+    it('should error when a module is not included in the object', async function () {
+      const code = "const moment = require('moment'); const ethers = require('ethers'); const notamodule = require('notamodule'); console.log(moment.now());";
+      await assert.rejects(transform(code, es6Option), Error, 'Napkin Modules: notamodule not found');
+    });
+  });
+});
+
+describe('commonjs', async function () {
+  describe('import transformations', async function () {
+    it('should handle imports', async function () {
+      const code = "import moment from 'moment'; import ethers from 'ethers'; console.log(moment.now());";
+      assert.equal(await transform(code), "\"use strict\";\n\nvar _moment = _interopRequireDefault(require(\"moment\"));\n\nvar _ethers = _interopRequireDefault(require(\"ethers-1.0.1\"));\n\nfunction _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { \"default\": obj }; }\n\nconsole.log(_moment[\"default\"].now());");
+    });
+
+    it('should error when a module is not included in the object', async function () {
+      const code = "import moment from 'moment'; import ethers from 'ethers'; import notamodule from 'notamodule'; console.log(moment.now());";
+      await assert.rejects(transform(code), Error, 'Napkin Modules: notamodule not found');
     });
   });
   
-  describe('call expression transformations', function () {
-    it('should handle requires without affecting other call expressions', function () {
+  describe('call expression transformations', async function () {
+    it('should handle requires without affecting other call expressions', async function () {
       const code = "const moment = require('moment'); const ethers = require('ethers'); console.log(moment.now());";
-      assert.equal(transform(code), "\"use strict\";\n\nvar moment = require(\"moment\");\n\nvar ethers = require(\"ethers-1.0.1\");\n\nconsole.log(moment.now());");
+      assert.equal(await transform(code), "\"use strict\";\n\nvar moment = require(\"moment\");\n\nvar ethers = require(\"ethers-1.0.1\");\n\nconsole.log(moment.now());");
     });
 
-    it('should error when a module is not included in the object', function () {
+    it('should error when a module is not included in the object', async function () {
       const code = "const moment = require('moment'); const ethers = require('ethers'); const notamodule = require('notamodule'); console.log(moment.now());";
-      assert.throws(() => { transform(code) }, Error, 'Napkin Modules: notamodule not found');
+      await assert.rejects(transform(code), Error, 'Napkin Modules: notamodule not found');
     });
   });
 });
 
-describe('node14 built-in modules', function () {
-  it('should properly transform in es6', function () {
+describe('node14 built-in modules', async function () {
+  it('should properly transform in es6', async function () {
     const code = "import { readFileSync } from 'fs'; const file = readFileSync('~/test.json');";
-    assert.equal(transform(code, es6Option), "import { readFileSync } from \"fs\";\nvar file = readFileSync('~/test.json');");
+    assert.equal(await transform(code, es6Option), "import { readFileSync } from \"fs\";\nvar file = readFileSync('~/test.json');");
   });
 
-  it('should properly transform in commonjs', function () {
+  it('should properly transform in commonjs', async function () {
     const code = "import { readFileSync } from 'fs'; const file = readFileSync('~/test.json');";
-    assert.equal(transform(code), "\"use strict\";\n\nvar _fs = require(\"fs\");\n\nvar file = (0, _fs.readFileSync)('~/test.json');");
+    assert.equal(await transform(code), "\"use strict\";\n\nvar _fs = require(\"fs\");\n\nvar file = (0, _fs.readFileSync)('~/test.json');");
   });
 });
 
-describe('importing something within a package', function () {
+describe('importing something within a package', async function () {
   const pluginOptions = {
     modules: {
       '@moment/foo': '*',
@@ -89,13 +106,13 @@ describe('importing something within a package', function () {
     }
   };
 
-  it('should properly transform in es6', function () {
+  it('should properly transform in es6', async function () {
     const code = "import momentFooPackage from '@moment/foo/package'; import ethersPackage from 'ethers/package'; console.log(momentFooPackage.call());";
-    assert.equal(transform(code, es6Option, pluginOptions), "import momentFooPackage from \"@moment/foo/package\";\nimport ethersPackage from \"ethers-1.0.1/package\";\nconsole.log(momentFooPackage.call());");
+    assert.equal(await transform(code, es6Option, pluginOptions), "import momentFooPackage from \"@moment/foo/package\";\nimport ethersPackage from \"ethers-1.0.1/package\";\nconsole.log(momentFooPackage.call());");
   });
 
-  it('should properly transform in commonjs', function () {
+  it('should properly transform in commonjs', async function () {
     const code = "const momentFooPackage = require('@moment/foo/package'); const ethersPackage = require('ethers/package'); console.log(momentFooPackage.call());";
-    assert.equal(transform(code, {}, pluginOptions), "\"use strict\";\n\nvar momentFooPackage = require(\"@moment/foo/package\");\n\nvar ethersPackage = require(\"ethers-1.0.1/package\");\n\nconsole.log(momentFooPackage.call());");
+    assert.equal(await transform(code, {}, pluginOptions), "\"use strict\";\n\nvar momentFooPackage = require(\"@moment/foo/package\");\n\nvar ethersPackage = require(\"ethers-1.0.1/package\");\n\nconsole.log(momentFooPackage.call());");
   });
 });


### PR DESCRIPTION
- change module format to es6 by adding `"type": "module"` in `package.json`
- update unit tests to use `transformAsync`
- run `npm audit fix` to resolve security vulnerabilities
- bump version to `0.1.0`